### PR TITLE
fix spawning of food tins

### DIFF
--- a/SixKeysOfTangrin/TangrinMap.cs
+++ b/SixKeysOfTangrin/TangrinMap.cs
@@ -209,20 +209,11 @@ public class TangrinMap : IMap
 
     public void VisibleItem()
     {
+        if (ItemInCurrentLocation() == ItemCollection.Nothing && rnd.NextDouble(1) > .95)
+            Items().UpdateItem(PlayerLocation, ItemCollection.TinOfFood);
+
         if (ItemInCurrentLocation() != ItemCollection.Nothing)
         {
-            if (rnd.NextDouble(1) > .95)
-            {
-                for (var i = 0; i < LocationCount; i++)
-                {
-                    if (Items().ItemLocations().ElementAt(i) == ItemCollection.Nothing)
-                    {
-                        Items().UpdateItem(PlayerLocation, 6);
-                        break;
-                    }
-                }
-            }
-
             outputDevice.ShowMessage(
                 $"{VisibleItemLocation()} is {ItemInCurrentLocationDescription()}.");
         }


### PR DESCRIPTION
The original code was updating (with a 5% probability) the current player location with a copper box if any location on the map contained no items (which is practically always)

The modified code places a tin of food with a 5% probability at the player's location if this particular location contains no items. In this way, the player has the possibility to occasionally eat and recover some strength.

Closes #11 